### PR TITLE
Revise depedencies

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -8,7 +8,7 @@
   "shortDescription": "Storage and communication infrastructure for a sovereign digital society",
   "type": "service",
   "mainService": "bee",
-  "architectures": ["linux/amd64", "linux/arm64"],
+  "architectures": ["linux/amd64"],
   "author": "rndlabs <packages@rndlabs.xyz> (https://github.com/rndlabs)",
   "contributors": [
     "mfw78 <mfw78@rndlabs.xyz> (https://github.com/mfw78)",

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -7,7 +7,7 @@ ENV REACT_APP_BEE_DEBUG_HOST=http://bee.swarm.public.dappnode:1635
 ENV REACT_APP_DEFAULT_RPC_URL=http://nethermind-xdai.dappnode:8545
 
 RUN apk add git build-base python3 && \
-    git clone --depth 1 --branch v0.20.2 https://github.com/ethersphere/bee-dashboard.git . && \
+    git clone --depth 1 --branch v0.23.0 https://github.com/ethersphere/bee-dashboard.git . && \
     npm uninstall puppeteer && \
     npm ci && \
     npm run build


### PR DESCRIPTION
This PR:

1. Removes `arm64` support due to inactive upstream (dappnode) `arm64` support / maintenance.
2. Bumps `bee-dashboard` to support staking, fixing #61 