### PR TITLE
fix: dappnode-sdk node v18 requirement

### DIFF
--- a/.github/workflows/auto_check.yml
+++ b/.github/workflows/auto_check.yml
@@ -11,7 +11,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
       - run: npx @dappnode/dappnodesdk github-action bump-upstream --timeout 2h
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto_check.yml
+++ b/.github/workflows/auto_check.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
-      - run: npx @dappnode/dappnodesdk github-action bump-upstream --timeout 2h
+      - run: npx @dappnode/dappnodesdk@0.3.6 github-action bump-upstream --timeout 2h
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PINATA_API_KEY: ${{ secrets.PINATA_API_KEY }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,10 @@ jobs:
     name: Build test
     if: github.event_name != 'push'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
       - run: npx @dappnode/dappnodesdk build --skip_save
 
   release:
@@ -23,7 +26,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
       - name: Publish
         run: npx @dappnode/dappnodesdk publish patch --github-release --eth_provider=${{ secrets.ETH_PROVIDER }} --content_provider=pinata
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
-      - run: npx @dappnode/dappnodesdk@3.0.6 build --skip_save
+      - run: npx @dappnode/dappnodesdk@0.3.6 build --skip_save
 
   release:
     name: Release
@@ -31,7 +31,7 @@ jobs:
         with:
           node-version: 18
       - name: Publish
-        run: npx @dappnode/dappnodesdk@3.0.6 publish patch --github-release --eth_provider=${{ secrets.ETH_PROVIDER }} --content_provider=pinata
+        run: npx @dappnode/dappnodesdk@0.3.6 publish patch --github-release --eth_provider=${{ secrets.ETH_PROVIDER }} --content_provider=pinata
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PINATA_API_KEY: ${{ secrets.PINATA_API_KEY }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
-      - run: npx @dappnode/dappnodesdk build --skip_save
+      - run: npx @dappnode/dappnodesdk@3.0.6 build --skip_save
 
   release:
     name: Release
@@ -31,7 +31,7 @@ jobs:
         with:
           node-version: 18
       - name: Publish
-        run: npx @dappnode/dappnodesdk publish patch --github-release --eth_provider=${{ secrets.ETH_PROVIDER }} --content_provider=pinata
+        run: npx @dappnode/dappnodesdk@3.0.6 publish patch --github-release --eth_provider=${{ secrets.ETH_PROVIDER }} --content_provider=pinata
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PINATA_API_KEY: ${{ secrets.PINATA_API_KEY }}


### PR DESCRIPTION
This PR:

* Bumps the checkout actions to v3
* Explicitly configures node v18 due to engine requirement changes on upstream dappnode-sdk.