### PR TITLE
Update dappnode package

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -26,13 +26,9 @@ If you wish to receive rewards for providing storage, you can *stake* `xBZZ` to 
 
 ### Staking
 
-Since `bee` version `1.10.0`, storage incentives have been activated for staking. The minimum to stake is `10 xBZZ`. Transfer this amount to your node's wallet using the methods above, and then you may execute the stake by using the following shell command:
+Since `bee` version `1.10.0`, storage incentives have been activated for staking. The minimum to stake is `10 xBZZ`. Transfer at least this amount to your node's wallet using the methods above, and then you goto the Bee dashboard (shown below) to use a UI for staking your node in the storage incentives competition.
 
-```bash
-curl http://bee.swarm.public.dappnode:1635/stake/100000000000000000 -X POST
-```
-
-The above parameter specifies 10 `xBZZ` in it's atomic units. **CAUTION:** Remember that BZZ uses **16 decimals**.
+**CAUTION:** Remember that BZZ uses **16 decimals**.
 
 ### Bee Dashboard
 

--- a/bee/entrypoint.sh
+++ b/bee/entrypoint.sh
@@ -6,4 +6,8 @@ if ! test -f /home/bee/.bee/password; then
     chown bee:bee /home/bee/.bee/password
 fi
 
-exec bee start ${EXTRA_OPTS}
+if [ "${BEE_NUKE_DB}" = "true" ]; then
+    exec bee db nuke --data-dir /home/bee/.bee
+else
+    exec bee start ${EXTRA_OPTS}
+fi

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -49,6 +49,14 @@
       "path": "/home/bee/.bee/localstore"
     },
     {
+      "name": "stamperstore",
+      "path": "/home/bee/.bee/stamperstore"
+    },
+    {
+      "name": "kademlia-metrics",
+      "path": "/home/bee/.bee/kademlia-metrics"
+    },
+    {
       "name": "password",
       "path": "/home/bee/.bee/password"
     }

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -7,7 +7,7 @@ ENV REACT_APP_BEE_DEBUG_HOST=http://bee.swarm.public.dappnode:1635
 ENV REACT_APP_DEFAULT_RPC_URL=http://nethermind-xdai.dappnode:8545
 
 RUN apk add git build-base python3 && \
-    git clone --depth 1 --branch v0.23.0 https://github.com/ethersphere/bee-dashboard.git . && \
+    git clone --depth 1 --branch v0.25.0 https://github.com/ethersphere/bee-dashboard.git . && \
     npm uninstall puppeteer && \
     npm ci && \
     npm run build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,9 @@ services:
       BEE_RESOLVER_OPTIONS: "http://erigon.dappnode:8545"
       BEE_FULL_NODE: "true"
       BEE_DEBUG_API_ENABLE: "true"
+      BEE_SWAP_ENABLE: "true"
+      BEE_TARGET_NEIGHBORHOOD: ""
+      BEE_NUKE_DB: "false"
       BEE_CORS_ALLOWED_ORIGINS: "*"
       BEE_WELCOME_MESSAGE: "Swarming on DAppNode \U0001F41D"
       BEE_PASSWORD_FILE: /home/bee/.bee/password

--- a/setup-wizard.yml
+++ b/setup-wizard.yml
@@ -44,6 +44,36 @@ fields:
       - "true"
       - "false"
     required: true
+  - title: Enable SWAP Incentives
+    id: enable-swap
+    description: SWAP bandwidth incentives allow for compensating bandwidth for serving data.
+    target:
+      type: environment
+      name: BEE_SWAP_ENABLE
+      service: bee
+    enum:
+      - "true"
+      - "false"
+    required: true
+  - title: Set target neighborhood
+    id: target-neighborhood
+    description: >-
+      Define a target neighbourhood in which to mine an overlay address. This is a complex undertaking, and it's recommended that you read the bee documentation https://docs.ethswarm.org/docs/bee/installation/install#set-target-neighborhood-optional
+    target:
+      type: environment
+      name: BEE_TARGET_NEIGHBORHOOD
+      service: bee
+  - title: Nuke database
+    id: nuke-db
+    description: >-
+      **DANGER**: Enabling this will nuke your localstore database
+    target:
+      type: environment
+      name: BEE_NUKE_DB
+      service: bee
+    enum:
+      - "true"
+      - "false"
   - id: swarmDataMountpoint
     target:
       type: allNamedVolumesMountpoint


### PR DESCRIPTION
This PR:

1. Introduces a `db` nuke option for recovering when migrations fail.
2. Fixes #114
3. Fixes #81 
4. Fixes #115 
5. Addresses most of #116 (points 2 and 3)